### PR TITLE
Feature add destroy

### DIFF
--- a/src/Singleton.hpp
+++ b/src/Singleton.hpp
@@ -27,13 +27,13 @@ public:
 	}
 	
 	static void destroyInstance()
-  {
-    if(msInstance != 0)
-    {
-      delete msInstance;
-      msInstance = 0;
-    }
-  }
+	{
+		if(msInstance != 0)
+		{
+			delete msInstance;
+			msInstance = 0;
+		}
+	}
 
 	virtual ~Singleton()
 	{

--- a/src/Singleton.hpp
+++ b/src/Singleton.hpp
@@ -25,6 +25,15 @@ public:
 	
 		return msInstance;
 	}
+	
+	static void destroyInstance()
+  {
+    if(msInstance != 0)
+    {
+      delete msInstance;
+      msInstance = 0;
+    }
+  }
 
 	virtual ~Singleton()
 	{

--- a/src/Singleton.hpp
+++ b/src/Singleton.hpp
@@ -28,11 +28,8 @@ public:
 	
 	static void destroyInstance()
 	{
-		if(msInstance != 0)
-		{
-			delete msInstance;
-			msInstance = 0;
-		}
+		delete msInstance;
+		msInstance = 0;
 	}
 
 	virtual ~Singleton()


### PR DESCRIPTION
In some cases you need to be in control of the destruction order of singletons.
Therefore I added a `destroyInstance` method.


My use case is in envire, due to plugin loading we get some complex initialization & destruction order and we need this method to resolve a bug.